### PR TITLE
技術チェック編集画面のバグ修正

### DIFF
--- a/HelloWorld/src/main/java/main.java
+++ b/HelloWorld/src/main/java/main.java
@@ -7,6 +7,7 @@ import java.sql.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static spark.Spark.*;
 
@@ -148,7 +149,25 @@ public class main {
             return new FreeMarkerEngine().render(new ModelAndView(attribute, "skill_check.ftl"));
         });
 
-        post("/career/skillCheck", (req, res) -> {
+        //技術の削除
+        post("/career/skillCheck/delete", (req, res) -> {
+            String name = req.queryParams("name");
+            String id = req.queryParams("id");
+            Map<String, Object> attribute = new HashMap<>();
+            attribute.put("id",id);
+
+            SkillsDao skillDao = new SkillsDaoImpl(DbConfig.singleton());
+            TransactionManager tm = DbConfig.singleton().getTransactionManager();
+
+            tm.required(() -> {
+                skillDao.update_delete_skill(Integer.valueOf(req.queryParams("id")));
+            });
+            res.redirect("/career/skillCheck");
+            return res;
+        });
+
+// 技術の追加
+        post("/career/skillCheck/add", (req, res) -> {
             String name = req.queryParams("name");
             String id = req.queryParams("id");
             Map<String, Object> attribute = new HashMap<>();
@@ -158,18 +177,18 @@ public class main {
             SkillsDao skillDao = new SkillsDaoImpl(DbConfig.singleton());
             TransactionManager tm = DbConfig.singleton().getTransactionManager();
 
-            tm.required(() -> {
-                skillDao.update_delete_skill(Integer.valueOf(req.queryParams("id")));
-            });
-            tm.required(() -> {
-                Skills skills = new Skills();
-                skills.setName(name);
-                skills.setSkill_attribute_id(Integer.valueOf(id));
-                skillDao.insertSkill(skills);
-            });
+            if(Objects.equals(id, "1") || Objects.equals(id, "2") || Objects.equals(id, "3")) {
+                tm.required(() -> {
+                    Skills skills = new Skills();
+                    skills.setName(name);
+                    skills.setSkill_attribute_id(Integer.valueOf(id));
+                    skillDao.insertSkill(skills);
+                });
+            }
             res.redirect("/career/skillCheck");
             return res;
         });
+
 
         //管理者権限編集画面
         get("/career/managementUpdate",(req,res) -> {

--- a/HelloWorld/src/main/resources/spark/template/freemarker/skill_check.ftl
+++ b/HelloWorld/src/main/resources/spark/template/freemarker/skill_check.ftl
@@ -34,11 +34,11 @@
             <tr>
                 <td class="skill_data">${os.name}</td>
                 <td class="skill_edit_delete"><button class="skill_edit_button">編集</button></td>
-                <form method="post" action="/career/skillCheck">
+                <form method="post" action="/career/skillCheck/delete">
                     <input type="hidden" value="${os.id}" name="id">
-                <td class="skill_edit_delete">
-                    <button type="submit" class="skill_delete_button">削除</button>
-                </td>
+                    <td class="skill_edit_delete">
+                        <button type="submit" class="skill_delete_button">削除</button>
+                    </td>
                 </form>
             </tr>
         </#list>
@@ -53,7 +53,7 @@
             <tr>
                 <td class="skill_data">${script.name}</td>
                 <td class="skill_edit_delete"><button class="skill_edit_button">編集</button></td>
-                <form method="post" action="/career/skillCheck">
+                <form method="post" action="/career/skillCheck/delete">
                     <input type="hidden" value="${script.id}" name="id">
                     <td class="skill_edit_delete">
                         <button type="submit" class="skill_delete_button">削除</button>
@@ -67,11 +67,11 @@
             <tr>
                 <th class="skill_name" colspan="3">データベース</th>
             </tr>
-        <#list db_lists as db>
+            <#list db_lists as db>
             <tr>
                 <td class="skill_data">${db.name}</td>
                 <td class="skill_edit_delete"><button class="skill_edit_button">編集</button></td>
-                <form method="post" action="/career/skillCheck">
+                <form method="post" action="/career/skillCheck/delete">
                     <input type="hidden" value="${db.id}" name="id">
                     <td class="skill_edit_delete">
                         <button type="submit" class="skill_delete_button">削除</button>
@@ -83,28 +83,29 @@
     </div>
 
     <div class="skill_wrapper_empty"></div>
-        <form method="post" action="/career/skillCheck">
-            <div class="skill_add">
-                <div class="skill_add_item">
-                    <input type="text" id="name" class="skill_add_name" name="name">
-                </div>
-
-                <div class="skill_add_item">
-                    <select name="id" class="skill_select">
-                        <option>技術を選択</option>
-                        <option value="1">OS</option>
-                        <option value="2">スクリプト・ツール</option>
-                        <option value="3">DB</option>
-                    </select>
-                </div>
-
-                <div class="skill_add_item">
-                    <input type="submit" name="add_button" class="skill_add_button" value="追加">
-                </div>
+    <form method="post" action="/career/skillCheck/add">
+        <div class="skill_add">
+            <div class="skill_add_item">
+                <input type="text" id="name" class="skill_add_name" name="name">
             </div>
-        </form>
+
+            <div class="skill_add_item">
+                <select name="id" class="skill_select">
+                    <option>技術を選択</option>
+                    <option value="1">OS</option>
+                    <option value="2">スクリプト・ツール</option>
+                    <option value="3">DB</option>
+                </select>
+            </div>
+
+            <div class="skill_add_item">
+                <input type="submit" name="add_button" class="skill_add_button" value="追加">
+            </div>
+        </div>
+    </form>
     <div class="skill_wrapper_empty"></div>
 </div>
 </body>
 </html>
+
 


### PR DESCRIPTION
変更ファイル
・main.java
・skill_check.ftl

変更点
・削除ボタンを押したら、削除される代わりに削除フラグを1に変えた項目のidとskill_attribute_idが同じの謎のNULLが追加されるバグを修正

postをひとまとめで作っていたから起きていたバグ。
削除フラグを１にするpostと追加するpostを分けたら解決しました。
あとついでに技術属性(skill_attribute_id)が選択されなかった場合、ページもDBも何も変わらない処理を追加