### PR TITLE
入社年月も実装しました

### DIFF
--- a/HelloWorld/src/main/java/EmployeesDao.java
+++ b/HelloWorld/src/main/java/EmployeesDao.java
@@ -77,7 +77,7 @@ public interface EmployeesDao {
     @Update(include= {"department_id","id"})
     int updateDepID(Employees employees);
 
-    //@Update(include= {"department_id","email"})
-    //int updateEmp(Employees employees);
+    @Update(include= {"join_date","id"})
+    int updateJoinDate(Employees employees);
 }
 

--- a/HelloWorld/src/main/java/main.java
+++ b/HelloWorld/src/main/java/main.java
@@ -449,7 +449,9 @@ public class main {
         //従業員テーブルの変更を保存する
         post("/career/empUpdate/keep",(req,res) -> {
             EmployeesDao empDao= new EmployeesDaoImpl(DbConfig.singleton());
+
             TransactionManager tm = DbConfig.singleton().getTransactionManager();
+            
             String departmentID = req.queryParams("input_dep_id");
             String joinDate = req.queryParams("input_joinDate");
             String Email = req.queryParams("input_email");
@@ -460,18 +462,21 @@ public class main {
             attribute.put("input_joinDate",joinDate);
             attribute.put("input_email",Email);
 
-            //employees.setDepartment_id(Integer.valueOf(req.queryParams("input_dep_id")));
-
-            //SimpleDateFormat sdFormat = new SimpleDateFormat("yyyy-MM-dd");
-            //Date Join = (Date) sdFormat.parse(joinDate);
-            //employees.setJoin_date(Join);
-
             if(!Objects.equals(departmentID, "0")){
                 tm.required(() -> {
                     Employees employees = new Employees();
                     employees.setDepartment_id(Integer.valueOf(req.queryParams("input_dep_id")));
                     employees.setId(Integer.valueOf(req.queryParams("id")));
                     empDao.updateDepID(employees);
+                });
+            }
+
+            if(!Objects.equals(joinDate, "")){
+                tm.required(() -> {
+                    Employees employees = new Employees();
+                    employees.setJoin_date(Date.valueOf(joinDate));
+                    employees.setId(Integer.valueOf(req.queryParams("id")));
+                    empDao.updateJoinDate(employees);
                 });
             }
 

--- a/HelloWorld/src/main/resources/spark/template/freemarker/emp_update.ftl
+++ b/HelloWorld/src/main/resources/spark/template/freemarker/emp_update.ftl
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="../style.css">
-    <title>業務経歴書</title>
+    <title>従業員編集画面</title>
 </head>
 <body>
 <!---------- ヘッダー部分　---------->


### PR DESCRIPTION
ただ、ちょっと問題がありまして

例えば、DBに入っていたAdachi.Kの入社年月は2023年だけど、ミスで2022-04-01が入ってたとします
その際は編集画面を開いてもらって、入社年月のテキストボックスをクリックして「2023/04/01」と入力してもらうと・・・

なんと、普通にエラーになります

実は、入社年月の変更がちょっと癖があるのです

入社年月を変更するには、入社年月のテキストボックスをクリックして
「2023-04-01」と入力してもらう必要があります

yyyy/MM/dd形式だとエラーになり、yyyy-MM-dd形式だと変更が可能ということです

マニュアルとかを用意しといたほうがよさそうですかね？