### PR TITLE
業務経歴書編集画面の保存ボタンのupdateと画面遷移が同時にできるようになりました

### DIFF
--- a/HelloWorld/src/main/java/main.java
+++ b/HelloWorld/src/main/java/main.java
@@ -227,11 +227,11 @@ public class main {
                 empDao.update_workHistry(employee);
 
 //                work_historiesの登録
-                Work_histories work_histories = historiesDao.selectById(Integer.valueOf(req.queryParams("id")));
-                work_histories.setProject_id(Integer.valueOf(project_id));
-                work_histories.setWork_start(Date.valueOf(work_start));
-                work_histories.setWork_end(Date.valueOf(work_end));
-                historiesDao.update(work_histories);
+    //            Work_histories work_histories = historiesDao.selectById(Integer.valueOf(req.queryParams("id")));
+    //            work_histories.setProject_id(Integer.valueOf(project_id));
+    //            work_histories.setWork_start(Date.valueOf(work_start));
+    //            work_histories.setWork_end(Date.valueOf(work_end));
+    //            historiesDao.update(work_histories);
 
 //                work_detailsの登録
 //                Work_details work_details = detailsDao.selectById(Integer.valueOf(req.queryParams(work_history_id)));
@@ -244,7 +244,8 @@ public class main {
 //                detailsDao.update(work_details);
             });
 
-            res.redirect("/career");
+            res.redirect("/career/show?id=" + id);
+
             return res;
 
         });

--- a/HelloWorld/src/main/resources/spark/template/freemarker/career_update.ftl
+++ b/HelloWorld/src/main/resources/spark/template/freemarker/career_update.ftl
@@ -33,7 +33,7 @@
 </form>
 <!---------- 保存ボタン ---------->
 <form method="post" action="/career/update">
-    <button type="submit" value="${id}" name="id" class="keep" onclick="location.href='http://localhost:4567/career/show'">保存</button>
+    <button type="submit" value="${id}" name="id" class="keep">保存</button>
 
 <!---------- 業務経歴書の部分 ---------->
 <div class="careerSheet">


### PR DESCRIPTION
career_update_ftlファイルをいじっても何も解決せず、
解決するためにはmain.javaをいじる必要がある

POST処理のリダイレクトで対象のIDの業務経歴書閲覧画面を500エラー出さずに表示させるには
res.redirect("/career/show?id=" + id);をすれば一発で解決

イメージ的にはjavaの
system.out.println("私の名前は" + name + "です");
みたいなアレですね、多分